### PR TITLE
feat(terrain): add TerrainManager

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -4,3 +4,6 @@ export * from './AssetManager.js';
 export * from './FormatManager.js';
 export * from './TextureManager.js';
 export * from './SceneWorker.js';
+export * from './terrain/TerrainManager.js';
+export * from './terrain/TerrainMesh.js';
+export * from './terrain/TerrainMaterial.js';

--- a/src/lib/terrain/TerrainManager.ts
+++ b/src/lib/terrain/TerrainManager.ts
@@ -1,0 +1,90 @@
+import * as THREE from 'three';
+import { MapChunk, MapArea } from '@wowserhq/format';
+import { createSplatTexture } from './material.js';
+import { createTerrainIndexBuffer, createTerrainVertexBuffer } from './geometry.js';
+import TextureManager from '../TextureManager.js';
+import TerrainMaterial from './TerrainMaterial.js';
+import TerrainMesh from './TerrainMesh.js';
+
+class TerrainManager {
+  #textureManager: TextureManager;
+  #loadedAreas = new globalThis.Map<number, THREE.Group>();
+  #loadingAreas = new globalThis.Map<number, Promise<THREE.Group>>();
+
+  constructor(textureManager: TextureManager) {
+    this.#textureManager = textureManager;
+  }
+
+  getArea(areaId: number, area: MapArea): Promise<THREE.Group> {
+    const loaded = this.#loadedAreas.get(areaId);
+    if (loaded) {
+      return Promise.resolve(loaded);
+    }
+
+    const alreadyLoading = this.#loadingAreas.get(areaId);
+    if (alreadyLoading) {
+      return alreadyLoading;
+    }
+
+    const loading = this.#loadArea(areaId, area);
+    this.#loadingAreas.set(areaId, loading);
+
+    return loading;
+  }
+
+  async #loadArea(areaId: number, area: MapArea) {
+    const group = new THREE.Group();
+    group.name = 'terrain';
+
+    for (const chunk of area.chunks) {
+      const mesh = await this.#createMesh(chunk);
+      group.add(mesh);
+    }
+
+    this.#loadedAreas.set(areaId, group);
+    this.#loadingAreas.delete(areaId);
+
+    return group;
+  }
+
+  async #createMesh(chunk: MapChunk) {
+    const [geometry, material] = await Promise.all([
+      this.#createGeometry(chunk),
+      this.#createMaterial(chunk),
+    ]);
+
+    return new TerrainMesh(chunk.position, geometry, material);
+  }
+
+  async #createGeometry(chunk: MapChunk) {
+    const [vertexBuffer, indexBuffer] = await Promise.all([
+      createTerrainVertexBuffer(chunk),
+      createTerrainIndexBuffer(chunk),
+    ]);
+
+    const geometry = new THREE.BufferGeometry();
+
+    const positions = new THREE.InterleavedBuffer(new Float32Array(vertexBuffer), 4);
+    geometry.setAttribute('position', new THREE.InterleavedBufferAttribute(positions, 3, 0, false));
+
+    const normals = new THREE.InterleavedBuffer(new Int8Array(vertexBuffer), 16);
+    geometry.setAttribute('normal', new THREE.InterleavedBufferAttribute(normals, 4, 12, true));
+
+    const index = new THREE.BufferAttribute(new Uint16Array(indexBuffer), 1, false);
+    geometry.setIndex(index);
+
+    return geometry;
+  }
+
+  async #createMaterial(chunk: MapChunk) {
+    const [splatTexture, ...layerTextures] = await Promise.all([
+      createSplatTexture(chunk.layers),
+      ...chunk.layers.map((layer) => this.#textureManager.get(layer.texture)),
+    ]);
+
+    return new TerrainMaterial(chunk.layers.length, layerTextures, splatTexture);
+  }
+}
+
+export default TerrainManager;
+export { TerrainManager };

--- a/src/lib/terrain/TerrainMaterial.ts
+++ b/src/lib/terrain/TerrainMaterial.ts
@@ -1,0 +1,25 @@
+import * as THREE from 'three';
+import { fragmentShader, vertexShader } from './shaders.js';
+
+class TerrainMaterial extends THREE.RawShaderMaterial {
+  constructor(layerCount: number, layerTextures: THREE.Texture[], splatTexture: THREE.Texture) {
+    super();
+
+    this.uniforms = {
+      layerCount: { value: layerCount },
+      layers: { value: layerTextures },
+      splat: { value: splatTexture },
+      fogColor: { value: new THREE.Color(0.25, 0.5, 0.8) },
+      fogParams: { value: new THREE.Vector3(0.0, 1066.0, 1.0) },
+    };
+
+    this.vertexShader = vertexShader;
+    this.fragmentShader = fragmentShader;
+    this.glslVersion = THREE.GLSL3;
+    this.side = THREE.FrontSide;
+    this.blending = 0;
+  }
+}
+
+export default TerrainMaterial;
+export { TerrainMaterial };

--- a/src/lib/terrain/TerrainMesh.ts
+++ b/src/lib/terrain/TerrainMesh.ts
@@ -1,0 +1,18 @@
+import * as THREE from 'three';
+
+class TerrainMesh extends THREE.Mesh {
+  constructor(position: Float32Array, geometry: THREE.BufferGeometry, material: THREE.Material) {
+    // We need these for frustum culling, so we might as well take the hit on creation
+    geometry.computeBoundingSphere();
+
+    super(geometry);
+
+    this.material = material;
+
+    this.position.set(position[0], position[1], position[2]);
+    this.updateMatrixWorld();
+  }
+}
+
+export default TerrainMesh;
+export { TerrainMesh };

--- a/src/lib/terrain/geometry.ts
+++ b/src/lib/terrain/geometry.ts
@@ -1,0 +1,15 @@
+import { MAP_CHUNK_FACE_COUNT_X, MAP_CHUNK_FACE_COUNT_Y, MapChunk } from '@wowserhq/format';
+import terrainWorker from './worker.js';
+
+const createTerrainVertexBuffer = (chunk: MapChunk) =>
+  terrainWorker.call('createTerrainVertexBuffer', chunk.vertexHeights, chunk.vertexNormals);
+
+const createTerrainIndexBuffer = (chunk: MapChunk) =>
+  terrainWorker.call(
+    'createTerrainIndexBuffer',
+    chunk.holes,
+    MAP_CHUNK_FACE_COUNT_X,
+    MAP_CHUNK_FACE_COUNT_Y,
+  );
+
+export { createTerrainVertexBuffer, createTerrainIndexBuffer };

--- a/src/lib/terrain/material.ts
+++ b/src/lib/terrain/material.ts
@@ -1,0 +1,54 @@
+import * as THREE from 'three';
+import { MAP_LAYER_SPLAT_X, MAP_LAYER_SPLAT_Y, MapLayer } from '@wowserhq/format';
+import terrainWorker from './worker.js';
+
+const SPLAT_TEXTURE_PLACEHOLDER = new THREE.Texture();
+
+const createSplatTexture = async (layers: MapLayer[]) => {
+  // Handle no splat
+
+  if (layers.length <= 1) {
+    // Return placeholder texture to keep uniforms consistent
+    return SPLAT_TEXTURE_PLACEHOLDER;
+  }
+
+  // Handle single splat (2 layers)
+
+  if (layers.length === 2) {
+    const texture = new THREE.DataTexture(
+      layers[1].splat,
+      MAP_LAYER_SPLAT_X,
+      MAP_LAYER_SPLAT_Y,
+      THREE.RedFormat,
+    );
+    texture.minFilter = texture.magFilter = THREE.LinearFilter;
+    texture.anisotropy = 16;
+    texture.needsUpdate = true;
+
+    return texture;
+  }
+
+  // Handle multiple splats (3+ layers)
+
+  const layerSplats = layers.slice(1).map((layer) => layer.splat);
+  const data = await terrainWorker.call(
+    'mergeLayerSplats',
+    layerSplats,
+    MAP_LAYER_SPLAT_X,
+    MAP_LAYER_SPLAT_Y,
+  );
+
+  const texture = new THREE.DataTexture(
+    data,
+    MAP_LAYER_SPLAT_X,
+    MAP_LAYER_SPLAT_Y,
+    THREE.RGBAFormat,
+  );
+  texture.minFilter = texture.magFilter = THREE.LinearFilter;
+  texture.anisotropy = 16;
+  texture.needsUpdate = true;
+
+  return texture;
+};
+
+export { createSplatTexture };

--- a/src/lib/terrain/shaders.ts
+++ b/src/lib/terrain/shaders.ts
@@ -1,0 +1,108 @@
+const vertexShader = `
+precision highp float;
+
+uniform mat4 modelMatrix;
+uniform mat4 modelViewMatrix;
+uniform mat4 projectionMatrix;
+uniform vec3 cameraPosition;
+
+in vec3 position;
+in vec3 normal;
+
+out vec2 layerCoord;
+out vec2 splatCoord;
+out float light;
+out float cameraDistance;
+
+void main() {
+  // Terrain tileset textures repeat 8 times over the terrain chunk
+  vec4 layerScale = vec4(-0.24, -0.24, 0.0, 0.0);
+  layerCoord.xy = position.xy * layerScale.xy;
+
+  // Splat textures do not repeat over the terrain chunk
+  vec4 splatScale = vec4(-0.03, -0.03, 0.0, 0.0);
+  splatCoord.yx = position.xy * splatScale.xy;
+
+  // TODO - Replace with lighting manager controlled value
+  vec3 lightDirection = vec3(-1, -1, -1);
+  light = dot(normal, -normalize(lightDirection));
+
+  // Calculate camera distance for fog coloring in fragment shader
+  vec4 worldPosition = modelMatrix * vec4(position, 1.0);
+  cameraDistance = distance(cameraPosition, worldPosition.xyz);
+
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+}
+`;
+
+const fragmentShader = `
+precision highp float;
+
+uniform int layerCount;
+uniform sampler2D layers[4];
+uniform sampler2D splat;
+uniform vec3 fogColor;
+uniform vec3 fogParams;
+
+in vec2 layerCoord;
+in vec2 splatCoord;
+in float light;
+in float cameraDistance;
+
+out vec4 color;
+
+vec4 applyFog(vec4 color) {
+  float fogStart = fogParams.x;
+  float fogEnd = fogParams.y;
+  float fogModifier = fogParams.z;
+
+  float fogFactor = (fogEnd - cameraDistance) / (fogEnd - fogStart);
+  fogFactor = clamp(fogFactor * fogModifier, 0.0,  1.0);
+
+  vec4 mixed = vec4(mix(color.rgb, fogColor.rgb, 1.0 - fogFactor), color.a);
+
+  return mixed;
+}
+
+vec4 blendLayer(vec4 color, vec4 layer, vec4 blend) {
+  return (layer * blend) + ((1.0 - blend) * color);
+}
+
+void main() {
+  vec4 layer;
+  vec4 blend;
+
+  // 1st layer
+  color = texture(layers[0], layerCoord);
+  blend = texture(splat, splatCoord);
+
+  // 2nd layer
+  if (layerCount > 1) {
+    layer = texture(layers[1], layerCoord);
+    color = blendLayer(color, layer, blend.rrrr);
+  }
+
+  if (layerCount > 2) {
+    layer = texture(layers[2], layerCoord);
+    color = blendLayer(color, layer, blend.gggg);
+  }
+
+  // 3rd layer
+  if (layerCount > 3) {
+    layer = texture(layers[3], layerCoord);
+    color = blendLayer(color, layer, blend.bbbb);
+  }
+
+  // Fixed lighting
+  vec3 lightDiffuse = normalize(vec3(0.25, 0.5, 1.0));
+  vec3 lightAmbient = normalize(vec3(0.5, 0.5, 0.5));
+  color.rgb *= lightDiffuse * light + lightAmbient;
+
+  color.rgb = applyFog(color).rgb;
+
+  // Terrain is always opaque
+  color.a = 1.0;
+}
+`;
+
+export { vertexShader, fragmentShader };

--- a/src/lib/terrain/worker.ts
+++ b/src/lib/terrain/worker.ts
@@ -1,0 +1,6 @@
+import context from './worker/context.js';
+import SceneWorker from '../SceneWorker.js';
+
+const terrainWorker = new SceneWorker('terrain-worker', context);
+
+export default terrainWorker;

--- a/src/lib/terrain/worker/context.ts
+++ b/src/lib/terrain/worker/context.ts
@@ -1,0 +1,9 @@
+import * as geometry from './geometry.js';
+import * as material from './material.js';
+
+const context = {
+  ...geometry,
+  ...material,
+};
+
+export default context;

--- a/src/lib/terrain/worker/geometry.ts
+++ b/src/lib/terrain/worker/geometry.ts
@@ -1,0 +1,142 @@
+import {
+  MAP_CHUNK_WIDTH,
+  MAP_CHUNK_HEIGHT,
+  MAP_CHUNK_FACE_COUNT_X,
+  MAP_CHUNK_FACE_COUNT_Y,
+  MAP_CHUNK_VERTEX_COUNT,
+  MAP_CHUNK_VERTEX_STEP_X,
+  MAP_CHUNK_VERTEX_STEP_Y,
+} from '@wowserhq/format';
+
+const isTerrainHole = (holes: number, x: number, y: number) => {
+  const column = (y / 2) | 0;
+  const row = (x / 2) | 0;
+  const hole = 1 << (column * 4 + row);
+
+  return (hole & holes) !== 0;
+};
+
+const getDefaultTerrainVertexBuffer = () => {
+  if (self['DEFAULT_TERRAIN_VERTEX_BUFFER']) {
+    return self['DEFAULT_TERRAIN_VERTEX_BUFFER'];
+  }
+
+  // Vertex coordinates for x-axis (forward axis)
+  const vxe = new Float32Array(MAP_CHUNK_FACE_COUNT_X + 1);
+  const vxo = new Float32Array(MAP_CHUNK_FACE_COUNT_X);
+  for (let i = 0; i < MAP_CHUNK_FACE_COUNT_X; i++) {
+    const vx = -(i * MAP_CHUNK_VERTEX_STEP_X);
+    vxe[i] = vx;
+    vxo[i] = vx - MAP_CHUNK_VERTEX_STEP_X / 2.0;
+  }
+  vxe[MAP_CHUNK_FACE_COUNT_X] = -MAP_CHUNK_HEIGHT;
+
+  // Vertex coordinates for y-axis (right axis)
+  const vye = new Float32Array(MAP_CHUNK_FACE_COUNT_Y + 1);
+  const vyo = new Float32Array(MAP_CHUNK_FACE_COUNT_Y);
+  for (let i = 0; i < MAP_CHUNK_FACE_COUNT_Y; i++) {
+    const vy = -(i * MAP_CHUNK_VERTEX_STEP_Y);
+    vye[i] = vy;
+    vyo[i] = vy - MAP_CHUNK_VERTEX_STEP_Y / 2.0;
+  }
+  vye[MAP_CHUNK_FACE_COUNT_Y] = -MAP_CHUNK_WIDTH;
+
+  const vertexBuffer = new ArrayBuffer(MAP_CHUNK_VERTEX_COUNT * 16);
+  const vertexBufferView = new DataView(vertexBuffer);
+
+  let i = 0;
+
+  for (let x = 0; x < MAP_CHUNK_FACE_COUNT_X + 1; x++) {
+    // Evens
+    for (let y = 0; y < MAP_CHUNK_FACE_COUNT_Y + 1; y++) {
+      vertexBufferView.setFloat32(i * 16 + 0, vxe[x], true);
+      vertexBufferView.setFloat32(i * 16 + 4, vye[y], true);
+
+      i++;
+    }
+
+    // Odds
+    if (x < MAP_CHUNK_FACE_COUNT_X) {
+      for (let y = 0; y < MAP_CHUNK_FACE_COUNT_Y; y++) {
+        vertexBufferView.setFloat32(i * 16 + 0, vxo[x], true);
+        vertexBufferView.setFloat32(i * 16 + 4, vyo[y], true);
+
+        i++;
+      }
+    }
+  }
+
+  self['DEFAULT_TERRAIN_VERTEX_BUFFER'] = vertexBuffer;
+
+  return vertexBuffer;
+};
+
+const createTerrainVertexBuffer = (vertexHeights: Float32Array, vertexNormals: Int8Array) => {
+  // Copy the default vertex buffer (contains x and y coordinates)
+  const data = getDefaultTerrainVertexBuffer().slice(0);
+  const view = new DataView(data);
+
+  for (let i = 0; i < vertexHeights.length; i++) {
+    const vertexOfs = i * 16;
+
+    view.setFloat32(vertexOfs + 8, vertexHeights[i], true);
+
+    const normalOfs = i * 3;
+    view.setInt8(vertexOfs + 12, vertexNormals[normalOfs + 0]);
+    view.setInt8(vertexOfs + 13, vertexNormals[normalOfs + 1]);
+    view.setInt8(vertexOfs + 14, vertexNormals[normalOfs + 2]);
+  }
+
+  return data;
+};
+
+const createTerrainIndexBuffer = (holes: number, faceCountX: number, faceCountY: number) => {
+  const data = new ArrayBuffer(faceCountX * faceCountY * 3 * 4 * 2);
+  const view = new DataView(data);
+
+  let i = 0;
+
+  for (let x = 0; x < faceCountX; x++) {
+    for (let y = 0; y < faceCountY; y++) {
+      if (isTerrainHole(holes, x, y)) {
+        continue;
+      }
+
+      const f = x * 17 + y + 9;
+
+      view.setUint16(i * 24 + 0, f, true);
+      view.setUint16(i * 24 + 2, f - 9, true);
+      view.setUint16(i * 24 + 4, f + 8, true);
+
+      view.setUint16(i * 24 + 6, f, true);
+      view.setUint16(i * 24 + 8, f - 8, true);
+      view.setUint16(i * 24 + 10, f - 9, true);
+
+      view.setUint16(i * 24 + 12, f, true);
+      view.setUint16(i * 24 + 14, f + 9, true);
+      view.setUint16(i * 24 + 16, f - 8, true);
+
+      view.setUint16(i * 24 + 18, f, true);
+      view.setUint16(i * 24 + 20, f + 8, true);
+      view.setUint16(i * 24 + 22, f + 9, true);
+
+      i++;
+    }
+  }
+
+  return data;
+};
+
+export {
+  MAP_CHUNK_WIDTH,
+  MAP_CHUNK_HEIGHT,
+  MAP_CHUNK_FACE_COUNT_X,
+  MAP_CHUNK_FACE_COUNT_Y,
+  MAP_CHUNK_VERTEX_COUNT,
+  MAP_CHUNK_VERTEX_STEP_X,
+  MAP_CHUNK_VERTEX_STEP_Y,
+  getDefaultTerrainVertexBuffer,
+  isTerrainHole,
+  createTerrainVertexBuffer,
+  createTerrainIndexBuffer,
+};

--- a/src/lib/terrain/worker/material.ts
+++ b/src/lib/terrain/worker/material.ts
@@ -1,0 +1,16 @@
+const mergeLayerSplats = (layerSplats: Uint8Array[], width: number, height: number) => {
+  const data = new Uint8Array(width * height * 4);
+
+  // Treat each layer splat as a separate color channel
+  for (let l = 0; l < layerSplats.length; l++) {
+    const layerSplat = layerSplats[l];
+
+    for (let i = 0; i < width * height; i++) {
+      data[i * 4 + l] = layerSplat[i];
+    }
+  }
+
+  return data;
+};
+
+export { mergeLayerSplats };


### PR DESCRIPTION
This PR introduces `TerrainManager` to manage the terrain meshes defined by map chunks in area data (`.adt`) files. Loaded terrain meshes are kept in an in-memory cache a la the other types of managers found in `@wowserhq/scene`.