### PR TITLE
feat(texture): move texture loading into worker

### DIFF
--- a/src/lib/texture/loader/TextureLoader.ts
+++ b/src/lib/texture/loader/TextureLoader.ts
@@ -1,0 +1,25 @@
+import SceneWorkerController from '../../worker/SceneWorkerController.js';
+import { TextureSpec } from './types.js';
+import { AssetHost } from '../../asset.js';
+
+const createWorker = () =>
+  new Worker(new URL('./worker.js', import.meta.url), {
+    name: 'texture-loader',
+    type: 'module',
+  });
+
+type TextureLoaderOptions = {
+  host: AssetHost;
+};
+
+class TextureLoader extends SceneWorkerController {
+  constructor(options: TextureLoaderOptions) {
+    super(createWorker, { host: options.host });
+  }
+
+  loadSpec(path: string): Promise<TextureSpec> {
+    return this.request('loadSpec', path);
+  }
+}
+
+export default TextureLoader;

--- a/src/lib/texture/loader/TextureLoaderWorker.ts
+++ b/src/lib/texture/loader/TextureLoaderWorker.ts
@@ -1,0 +1,52 @@
+import { Blp } from '@wowserhq/format';
+import { TextureSpec } from './types.js';
+import SceneWorker from '../../worker/SceneWorker.js';
+import { AssetHost, loadAsset } from '../../asset.js';
+
+type TextureLoaderWorkerOptions = {
+  host: AssetHost;
+};
+
+class TextureLoaderWorker extends SceneWorker {
+  #host: AssetHost;
+
+  initialize(options: TextureLoaderWorkerOptions) {
+    this.#host = options.host;
+  }
+
+  async loadSpec(path: string) {
+    const blpData = await loadAsset(this.#host, path);
+    const blp = new Blp().load(blpData);
+
+    const images = blp.getImages();
+    const format = images[0].format;
+
+    const mipmaps = new Array(images.length);
+    const buffers = new Set<ArrayBuffer>();
+
+    for (let i = 0; i < images.length; i++) {
+      const image = images[i];
+
+      mipmaps[i] = {
+        width: image.width,
+        height: image.height,
+        data: image.data,
+      };
+
+      buffers.add(image.data.buffer);
+    }
+
+    const spec: TextureSpec = {
+      width: blp.width,
+      height: blp.height,
+      format,
+      mipmaps,
+    };
+
+    const transfer = [...buffers];
+
+    return [spec, transfer];
+  }
+}
+
+export default TextureLoaderWorker;

--- a/src/lib/texture/loader/types.ts
+++ b/src/lib/texture/loader/types.ts
@@ -1,0 +1,16 @@
+import { BLP_IMAGE_FORMAT } from '@wowserhq/format';
+
+type TextureMipmapSpec = {
+  width: number;
+  height: number;
+  data: Uint8Array;
+};
+
+type TextureSpec = {
+  width: number;
+  height: number;
+  format: BLP_IMAGE_FORMAT;
+  mipmaps: TextureMipmapSpec[];
+};
+
+export { TextureSpec };

--- a/src/lib/texture/loader/worker.ts
+++ b/src/lib/texture/loader/worker.ts
@@ -1,0 +1,3 @@
+import TextureLoaderWorker from './TextureLoaderWorker.js';
+
+const worker = new TextureLoaderWorker();


### PR DESCRIPTION
Similar to #30, this PR moves texture loading into a worker. Note that loading in this case does not include uploading to the GPU, which still happens in the main thread.